### PR TITLE
Misc AV1 parsing fixes

### DIFF
--- a/src/formats/av1/av1-bitstream.tsx
+++ b/src/formats/av1/av1-bitstream.tsx
@@ -189,7 +189,6 @@ export const AV1 = (buffers: BitBuffer[]) => {
 };
 
 export const open_bitstream_unit = syntax("open_bitstream_unit", (bs: Bitstream<ObuCtx & ParserCtx>, sz: number) => {
-    bs.updateCtx(new ObuCtx());
     const c = bs.ctx;
 
     const obu_header = () => {
@@ -230,7 +229,7 @@ export const open_bitstream_unit = syntax("open_bitstream_unit", (bs: Bitstream<
 
     if (c.obu_type == OBU_TYPE.OBU_SEQUENCE_HEADER) {
         bs.setTitle("OBU_SEQUENCE_HEADER");
-        // bs.error("sequence_header_obu(): Not implemented");
+        bs.updateCtx(new ObuCtx());
         sequence_header_obu(bs);
     }
     else if (c.obu_type == OBU_TYPE.OBU_TEMPORAL_DELIMITER) {
@@ -255,7 +254,6 @@ export const open_bitstream_unit = syntax("open_bitstream_unit", (bs: Bitstream<
     }
     else if (c.obu_type == OBU_TYPE.OBU_FRAME) {
         bs.setTitle("OBU_FRAME");
-        // bs.error("frame_obu(): Not implemented");
         frame_obu(bs, c.obu_size);
     }
     else if (c.obu_type == OBU_TYPE.OBU_TILE_LIST) {

--- a/src/formats/av1/obu/obu_frame_header.tsx
+++ b/src/formats/av1/obu/obu_frame_header.tsx
@@ -89,8 +89,8 @@ const frame_size = syntax("frame_size", (bs: Bitstream<ObuCtx>) => {
             c.SuperresDenom = SUPERRES_NUM
         }
         c.UpscaledWidth = c.FrameWidth
-        c.FrameWidth = (c.UpscaledWidth * SUPERRES_NUM +
-            (c.SuperresDenom / 2)) / c.SuperresDenom
+        c.FrameWidth = Math.trunc((c.UpscaledWidth * SUPERRES_NUM +
+            Math.trunc(c.SuperresDenom / 2)) / c.SuperresDenom)
     });
 
     if (c.frame_size_override_flag) {

--- a/src/formats/av1/obu/obu_tile_group.tsx
+++ b/src/formats/av1/obu/obu_tile_group.tsx
@@ -213,20 +213,22 @@ export const tile_group_obu = syntax("tile_group_obu", (bs: Bitstream<ObuCtx>, s
             c.tileSize = c.tile_size_minus_1 + 1
             sz -= c.tileSize + c.TileSizeBytes
         }
+        bs.f("tile_data", c.tileSize * 8);
         c.MiRowStart = c.MiRowStarts[c.tileRow]
         c.MiRowEnd = c.MiRowStarts[c.tileRow + 1]
         c.MiColStart = c.MiColStarts[c.tileCol]
         c.MiColEnd = c.MiColStarts[c.tileCol + 1]
         c.CurrentQIndex = c.base_q_idx
-        init_symbol(bs, c.tileSize);
-        decode_tile(bs)
+        //init_symbol(bs, c.tileSize);
+        //decode_tile(bs)
         // exit_symbol()
     }
-    // if (c.tg_end == NumTiles - 1) {
+
+    if (c.tg_end == c.NumTiles - 1) {
     //     if (!disable_frame_end_update_cdf) {
     //         frame_end_update_cdf()
     //     }
     //     decode_frame_wrapup()
-    //     SeenFrameHeader = 0
-    // }
+         c.SeenFrameHeader = 0
+    }
 });

--- a/src/formats/av1/obu/tile_info.tsx
+++ b/src/formats/av1/obu/tile_info.tsx
@@ -48,7 +48,7 @@ export const tile_info = syntax("tile_info", (bs: Av1Bs) => {
         }
         c.tileHeightSb = (c.sbRows + (1 << c.TileRowsLog2) - 1) >> c.TileRowsLog2
         i = 0
-        for (let startSb = 0; c.startSb < c.sbRows; startSb += c.tileHeightSb) {
+        for (let startSb = 0; startSb < c.sbRows; startSb += c.tileHeightSb) {
             c.MiRowStarts[i] = c.startSb << c.sbShift
             i += 1
         }


### PR DESCRIPTION
1. Only reset OBU context on each `OBU_SEQUENCE_HEADER`, not on every OBU
- This is required because `reduced_still_picture_header` (in `OBU_SEQUENCE_HEADER`) is a required value by `frame_size_override_flag` (in `OBU_FRAME`)
2. Fix `FrameWidth` calculation to use "truncate to zero" integer logic to match AV1 spec
3. Fixed typo in `tile_row` calculation
4. Fix `tile_group_obu` parsing

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bb16ad3a-11ef-4a37-a024-32c1237b391e">

Fixes #2 