### PR TITLE
Gracefully handle arrays in explorer

### DIFF
--- a/src/bitstream/bitstream-explorer.tsx
+++ b/src/bitstream/bitstream-explorer.tsx
@@ -67,7 +67,7 @@ function BitstreamSelection({ children }: {
     const getBitColor = useCallback((bitPos: number) => {
         for (let i = 0; i < ranges.length; i++) {
             if (ranges[i].inRange(bitPos)) {
-                return COLORS[i];
+                return COLORS[i > 0 ? 1 : 0];
             }
         }
         return undefined;
@@ -77,7 +77,7 @@ function BitstreamSelection({ children }: {
         const bitRange = new BitRange(bytePos * 8, (bytePos + 1) * 8);
         for (let i = 0; i < ranges.length; i++) {
             if (ranges[i].intersect(bitRange).count() > 0) {
-                return COLORS[i];
+                return COLORS[i > 0 ? 1 : 0];
             }
         }
         return undefined;

--- a/src/bitstream/parser.tsx
+++ b/src/bitstream/parser.tsx
@@ -60,6 +60,7 @@ export class Bitstream<T extends {} = ParserCtx> {
                 title,
                 start: startBitPos,
                 size: this.getPos() - startBitPos,
+                skip: 0,
                 value,
                 hidden
             });
@@ -77,12 +78,17 @@ export class Bitstream<T extends {} = ParserCtx> {
                     title: varName.toString(),
                     start: startBitPos,
                     size: this.getPos() - startBitPos,
+                    skip: 0,
                     value: [],
                     hidden
                 };
                 this.current.children?.push(syntaxDataNode);
+            } else {
+                if (!syntaxDataNode.skip) {
+                    syntaxDataNode.skip = startBitPos - (syntaxDataNode.start + syntaxDataNode.size);
+                }
+                syntaxDataNode.size += this.getPos() - startBitPos;
             }
-
 
             let arr = this.ctx[varName] as any[];
             let syntaxArr = syntaxDataNode.value as any[];
@@ -108,10 +114,6 @@ export class Bitstream<T extends {} = ParserCtx> {
             }
             syntaxArr[index] = value;
         }
-
-
-
-
     }
 
     f(varPath: string, bits: number, { e, hidden = false }: { e?: any, hidden?: boolean } = {}) {

--- a/src/components/syntax-table.tsx
+++ b/src/components/syntax-table.tsx
@@ -41,9 +41,26 @@ function DataTreeNode({ node, level = 0, maxNodeSize }: {
 
     const select = useCallback(() => {
         if (node.size == 0) return;
-        const newRange = new BitRange(node.start, node.start + node.size);
-        // if (ranges.length == 1 && ranges[0].equals(newRange)) return;
-        setRanges([newRange]);
+
+        let syntaxArr = node.value as any[];
+
+        if (!Array.isArray(syntaxArr)) {
+            // Single value
+            const newRange = new BitRange(node.start, node.start + node.size);
+            setRanges([newRange]);
+        } else {
+            // Multiple values - only first will be available in byte inspector
+            let subStart = node.start;
+            let subSize = node.size / syntaxArr?.length;
+            let ranges: BitRange[] = [];
+
+            for (let i = 0; i < syntaxArr?.length; i++) {
+                const newRange = new BitRange(subStart, subStart + subSize);
+                ranges.push(newRange);
+                subStart += subSize + node.skip;
+            }
+            setRanges(ranges);
+        }
     }, [node, setRanges]);
 
     const toggleExpand = () => setExpanded(exp => !exp);

--- a/src/types/parser.types.ts
+++ b/src/types/parser.types.ts
@@ -10,7 +10,8 @@ export type DataNode = {
     varName: string,
     value?: DataNodeValue,
     start: number,
-    size: number
+    size: number,
+    skip: number,
     hidden?: boolean
     filtered?: boolean
 }


### PR DESCRIPTION
- Report total array length in bits
- Select all ranges where the array is present in `HexEditor` instead of just the first range (only first element will be active in `ByteInspector`)

<img width="1470" alt="arrays" src="https://github.com/user-attachments/assets/25653e21-b6ef-4e8e-9bcf-4aed3c96e58f">
